### PR TITLE
Update Docker link to stop pointing to a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pyrodactyl is the Pterodactyl-based game server management panel that focuses on
 ## Running Pyrodactyl
 
 > [!TIP]
-> Pyrodactyl now [has a Docker image avaliable](https://github.com/pyrohost/pyrodactyl/pkgs/container/panel), which for previous users of the Pterodactyl panel in Docker, should make it easy to migrate.
+> Pyrodactyl now [has a Docker image avaliable](https://github.com/pyrohost/pyrodactyl/pkgs/container/pyrodactyl), which for previous users of the Pterodactyl panel in Docker, should make it easy to migrate.
 >
 > If you want to setup Pyrodactyl in Docker from scratch, see the [`docker-compose.example.yml`](https://github.com/pyrohost/pyrodactyl/blob/main/docker-compose.example.yml).
 


### PR DESCRIPTION
Hi!

I noticed that you support Docker now, but the link itself brought me to a 404 page, which I found out was due to the fact that you forgot to update the link from `panel` to `pyrodactyl`.

Normally I'd just open an issue about this, but since you seem to have that disabled, I just fixed it and opened this PR for it.

Thanks,
dynamyc