### PR TITLE
fix: Remove crash when viewing allocations page

### DIFF
--- a/app/Http/Controllers/Admin/Nodes/NodeViewController.php
+++ b/app/Http/Controllers/Admin/Nodes/NodeViewController.php
@@ -79,7 +79,7 @@ class NodeViewController extends Controller
       'node' => $node,
       'allocations' => Allocation::query()->where('node_id', $node->id)
         ->groupBy('ip')
-        ->orderByRaw('ip::inet ASC')
+        ->orderByRaw('INET_ATON(ip) ASC')
         ->get(['ip']),
     ]);
   }

--- a/app/Repositories/Eloquent/NodeRepository.php
+++ b/app/Repositories/Eloquent/NodeRepository.php
@@ -102,7 +102,7 @@ class NodeRepository extends EloquentRepository implements NodeRepositoryInterfa
       'allocations',
       $node->allocations()
         ->orderByRaw('server_id IS NOT NULL DESC, server_id IS NULL')
-        ->orderByRaw('ip::inet ASC')
+        ->orderByRaw('INET_ATON(ip) ASC')
         ->orderBy('port')
         ->with('server:id,name')
         ->paginate(50)


### PR DESCRIPTION
Changes the allocations function to use `INET_ATON` when using `orderByRaw`, matching upstream. Addresses #196 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the sorting method for displaying allocation IP addresses, resulting in a refreshed ordering in the list view for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->