### PR TITLE
Fix broken db driver connection

### DIFF
--- a/app/Repositories/Eloquent/EloquentRepository.php
+++ b/app/Repositories/Eloquent/EloquentRepository.php
@@ -275,7 +275,7 @@ abstract class EloquentRepository extends Repository implements RepositoryInterf
     $connection = $this->getBuilder()->getConnection();
     $driver = $connection->getDriverName();
 
-    if ($driver === 'mysql') {
+    if ($driver === 'mysql' || $driver == 'mariadb') {
       $statement = "INSERT IGNORE INTO $table ($columns) VALUES $parameters";
     } elseif ($driver === 'pgsql') {
       $statement = "INSERT INTO $table ($columns) VALUES $parameters ON CONFLICT DO NOTHING";


### PR DESCRIPTION
This bug caused a 500 error on the default docker-compose project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded database support now accommodates both MySQL and MariaDB. This update enhances system stability across varying environments, ensuring consistent performance and reducing operational issues. Users benefiting from either database system will experience a more robust and reliable deployment with notably improved scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->