### PR TITLE
feat(docker dev): use host network

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -109,17 +109,17 @@ fi
 
     # Create a developer user
     php artisan p:user:make -n --email dev@pyro.host --username dev --name-first Developer --name-last User --password password
-    mariadb -u root -h database -p"$DB_ROOT_PASSWORD" --ssl=0 -e "USE panel; UPDATE users SET root_admin = 1;" # workaround because --admin is broken
+    mariadb -u root -h $DB_HOST -p"$DB_ROOT_PASSWORD" --ssl=0 -e "USE panel; UPDATE users SET root_admin = 1;" # workaround because --admin is broken
     
     # Make a location and node for the panel
     php artisan p:location:make -n --short local --long Local
     php artisan p:node:make -n --name local --description "Development Node" --locationId 1 --fqdn $WINGS_IP --public 1 --scheme http --proxy 0 --maxMemory 1024 --maxDisk 10240 --overallocateMemory 0 --overallocateDisk 0
     
     echo "Adding dummy allocations..."
-    mariadb -u root -h database -p"$DB_ROOT_PASSWORD" --ssl=0 -e "USE panel; INSERT INTO allocations (node_id, ip, port) VALUES (1, '0.0.0.0', 25565), (1, '0.0.0.0', 25566), (1, '0.0.0.0', 25567);"
+    mariadb -u root -h $DB_HOST -p"$DB_ROOT_PASSWORD" --ssl=0 -e "USE panel; INSERT INTO allocations (node_id, ip, port) VALUES (1, '0.0.0.0', 25565), (1, '0.0.0.0', 25566), (1, '0.0.0.0', 25567);"
     
     echo "Creating database user..."
-    mariadb -u root -h database -p"$DB_ROOT_PASSWORD" --ssl=0 -e "CREATE USER 'pterodactyluser'@'%' IDENTIFIED BY 'somepassword'; GRANT ALL PRIVILEGES ON *.* TO 'pterodactyluser'@'%' WITH GRANT OPTION;"
+    mariadb -u root -h $DB_HOST -p"$DB_ROOT_PASSWORD" --ssl=0 -e "CREATE USER 'pterodactyluser'@'%' IDENTIFIED BY 'somepassword'; GRANT ALL PRIVILEGES ON *.* TO 'pterodactyluser'@'%' WITH GRANT OPTION;"
 
     # Configure node
     export WINGS_CONFIG=/etc/pterodactyl/config.yml

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,22 +1,11 @@
 x-common:
-    wings: &wings-environment
-        # The panel needs the to use the same FQDN/IP accessible in both the container & host, so a static IP is required.
-        # If you change it, you will need to update it in "http://localhost:3000/admin/nodes/view/1/settings" too, or down
-        # the compose, delete the "srv" folder, then up it again.
-        #
-        # Rootless Docker can't expose the IPs, so accessing Wings from the host won't work.
-        # https://docs.docker.com/engine/security/rootless/#known-limitations
-        #
-        # macOS Docker Desktop users will need to install https://github.com/chipmk/docker-mac-net-connect for Wings to work.
-        # macOS OrbStack & Linux users shouldn't need to install the above.
-        ipv4: &wings-ipv4 172.20.0.99
     database: &db-environment
         # Do not remove the "&db-password" from the end of the line below, it is important
         # for Panel functionality.
         MYSQL_PASSWORD: &db-password 'password'
         MYSQL_ROOT_PASSWORD: &db-root-password 'rootpassword'
     panel: &panel-environment
-        APP_URL: 'http://panel'
+        APP_URL: 'http://localhost'
         # A list of valid timezones can be found here: http://php.net/manual/en/timezones.php
         APP_TIMEZONE: 'UTC'
         APP_SERVICE_AUTHOR: 'noreply@example.com'
@@ -48,6 +37,7 @@ services:
         image: mariadb:10.5
         restart: always
         command: --default-authentication-plugin=mysql_native_password
+        network_mode: host
         volumes:
             - './srv/database:/var/lib/mysql'
         environment:
@@ -57,15 +47,17 @@ services:
     cache:
         image: redis:alpine
         restart: always
+        network_mode: host
     panel:
         image: pyrodactyl:develop
         restart: always
-        ports:
-            - '3000:80'
-            # - '443:443'
-        links:
-            - database
-            - cache
+        network_mode: host
+        # ports:
+        #     - '3000:80'
+        #     - '443:443'
+        # links:
+        #     - database
+        #     - cache
         volumes:
             - '.:/app'
             - './srv/var:/app/var'
@@ -73,9 +65,8 @@ services:
             - './srv/certs:/etc/letsencrypt'
             - './srv/logs/:/app/storage/logs'
             - './srv/pterodactyl/config/:/etc/pterodactyl'
-            # anonymous volumes below, meaning it'll use the image's directory instead of the host
+            # anonymous volumes below, meaning it'll use the image's vendor directory
             - '/app/vendor'
-            # needed for linux permissions
             - '/app/storage'
             - '/app/storage/framework/views'
             - '/app/bootstrap/cache'
@@ -88,27 +79,26 @@ services:
             CACHE_DRIVER: 'redis'
             SESSION_DRIVER: 'redis'
             QUEUE_DRIVER: 'redis'
-            REDIS_HOST: 'cache'
+            REDIS_HOST: '127.0.0.1'
             DB_CONNECTION: 'mariadb'
-            DB_HOST: 'database'
+            DB_HOST: '127.0.0.1'
             DB_PORT: '3306'
             HASHIDS_LENGTH: 8
-            WINGS_IP: *wings-ipv4
-            WINGS_DIR: '${PWD}'
+            WINGS_IP: 'localhost'
+            WINGS_DIR: *files-root
             PYRODACTYL_DOCKER_DEV: 'true'
     wings:
-        # The default Wings image doesn't work on macOS Docker
-        # This fork simply removes the incompatible `io.priority` cgroup v2 flag
-        # For Linux users, you can use the default image by uncommenting the line below
+        # The default Wings image doesn't work on macOS Docker. This fork simply removes the incompatible
+        # io.priority cgroup v2 flag. Linux users can use the default image, you can use it by uncommenting
+        # the line below
+
         # image: ghcr.io/pterodactyl/wings:latest
         image: ghcr.io/he3als/wings-mac:latest
         restart: always
-        networks:
-            default:
-                ipv4_address: *wings-ipv4
-        ports:
-            - '8080:8080'
-            - '2022:2022'
+        network_mode: host
+        # ports:
+        #     - '8080:8080'
+        #     - '2022:2022'
         tty: true
         environment:
             TZ: 'UTC'
@@ -132,9 +122,3 @@ services:
             - '${PWD}/srv/wings/docker/containers/:${PWD}/srv/wings/docker/containers/'
             - '${PWD}/srv/wings/:${PWD}/srv/wings/'
             - '${PWD}/srv/wings/logs/:${PWD}/srv/wings/logs/'
-
-networks:
-    default:
-        ipam:
-            config:
-                - subnet: 172.20.0.0/16

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "lint": "eslint ./resources/scripts --ext .ts,.tsx --fix",
         "lint:turbo": "turbo lint",
         "dev": "vite",
-        "dev:docker": "cross-env APP_URL=\"http://localhost:3000\" vite",
+        "dev:docker": "cross-env APP_URL=\"http://localhost\" vite",
         "compose": "docker compose down && docker compose up -d",
         "compose:down": "docker compose down",
         "build": "vite build",


### PR DESCRIPTION
Simplifies Docker dev method by using the host network type instead of bridge, which removes the requirement for a static internal IP for Wings accessible from the host.

Should fix rootless Docker and potentially Windows support (untested). Also removes the requirement for https://github.com/chipmk/docker-mac-net-connect on macOS.

Docs PR: https://github.com/pyrohost/pyrodactyl-docs/pull/16