### PR TITLE
Fixing .. folder creation error by preventing rendering of folder

### DIFF
--- a/resources/scripts/components/server/files/NewDirectoryButton.tsx
+++ b/resources/scripts/components/server/files/NewDirectoryButton.tsx
@@ -12,8 +12,8 @@ import { Dialog, DialogWrapperContext } from '@/components/elements/dialog';
 import asDialog from '@/hoc/asDialog';
 
 import createDirectory from '@/api/server/files/createDirectory';
-import { FileObject } from '@/api/server/files/loadDirectory';
 
+// import { FileObject } from '@/api/server/files/loadDirectory';
 import { ServerContext } from '@/state/server';
 
 import useFileManagerSwr from '@/plugins/useFileManagerSwr';
@@ -27,20 +27,22 @@ const schema = object().shape({
     directoryName: string().required('A valid directory name must be provided.'),
 });
 
-const generateDirectoryData = (name: string): FileObject => ({
-    key: `dir_${name.split('/', 1)[0] ?? name}`,
-    name: name.replace(/^(\/*)/, '').split('/', 1)[0] ?? name,
-    mode: 'drwxr-xr-x',
-    modeBits: '0755',
-    size: 0,
-    isFile: false,
-    isSymlink: false,
-    mimetype: '',
-    createdAt: new Date(),
-    modifiedAt: new Date(),
-    isArchiveType: () => false,
-    isEditable: () => false,
-});
+// removed to prevent linting issues, you're welcome.
+//
+// const generateDirectoryData = (name: string): FileObject => ({
+//     key: `dir_${name.split('/', 1)[0] ?? name}`,
+//     name: name.replace(/^(\/*)/, '').split('/', 1)[0] ?? name,
+//     mode: 'drwxr-xr-x',
+//     modeBits: '0755',
+//     size: 0,
+//     isFile: false,
+//     isSymlink: false,
+//     mimetype: '',
+//     createdAt: new Date(),
+//     modifiedAt: new Date(),
+//     isArchiveType: () => false,
+//     isEditable: () => false,
+// });
 
 const NewDirectoryDialog = asDialog({
     title: 'New Folder',
@@ -60,7 +62,8 @@ const NewDirectoryDialog = asDialog({
 
     const submit = ({ directoryName }: Values, { setSubmitting }: FormikHelpers<Values>) => {
         createDirectory(uuid, directory, directoryName)
-            .then(() => mutate((data) => [...data!, generateDirectoryData(directoryName)], false))
+            // .then(() => mutate((data) => [...data!, generateDirectoryData(directoryName)], false))
+            .then(() => mutate())
             .then(() => close())
             .catch((error) => {
                 setSubmitting(false);


### PR DESCRIPTION
## Related issues
This fix addresses issue(s):
- [x] #240

## Behaviour
This bug is caused by the client updating the file list when a new folder is created, even if it has not actually been created. This means that when the folder is to then be deleted, because the folder does not exist, it does not get deleted and results in an error.

## What's been done
The mutate function for the new directory handler has been changed to `mutate` instead of the original `mutate((data) => [...data!, generateDirectoryData(directoryName)], false)`[^1] as the extra addition resulted in this behavior. The reason for this design is unknown to me and quite puzzling.

[^1]: This has been tested on vagrant and behaves correctly. This is done with the current tested assumption that leaving mutate blank forces the data to be regathered from the server, which is the same behavior as file uploads.
