### PR TITLE
feat: add wings internal fqdn option

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -113,7 +113,7 @@ fi
     
     # Make a location and node for the panel
     php artisan p:location:make -n --short local --long Local
-    php artisan p:node:make -n --name local --description "Development Node" --locationId 1 --fqdn $WINGS_IP --public 1 --scheme http --proxy 0 --maxMemory 1024 --maxDisk 10240 --overallocateMemory 0 --overallocateDisk 0
+    php artisan p:node:make -n --name local --description "Development Node" --locationId 1 --fqdn localhost --internal-fqdn $WINGS_INTERNAL_IP --public 1 --scheme http --proxy 0 --maxMemory 1024 --maxDisk 10240 --overallocateMemory 0 --overallocateDisk 0
     
     echo "Adding dummy allocations..."
     mariadb -u root -h database -p"$DB_ROOT_PASSWORD" --ssl=0 -e "USE panel; INSERT INTO allocations (node_id, ip, port) VALUES (1, '0.0.0.0', 25565), (1, '0.0.0.0', 25566), (1, '0.0.0.0', 25567);"

--- a/app/Console/Commands/Node/MakeNodeCommand.php
+++ b/app/Console/Commands/Node/MakeNodeCommand.php
@@ -12,6 +12,7 @@ class MakeNodeCommand extends Command
                             {--description= : A description to identify the node.}
                             {--locationId= : A valid locationId.}
                             {--fqdn= : The domain name (e.g node.example.com) to be used for connecting to the daemon. An IP address may only be used if you are not using SSL for this node.}
+                            {--internal-fqdn= : Internal domain name for panel-to-Wings communication (optional).}
                             {--public= : Should the node be public or private? (public=1 / private=0).}
                             {--scheme= : Which scheme should be used? (Enable SSL=https / Disable SSL=http).}
                             {--proxy= : Is the daemon behind a proxy? (Yes=1 / No=0).}
@@ -51,6 +52,7 @@ class MakeNodeCommand extends Command
             'https'
         );
         $data['fqdn'] = $this->option('fqdn') ?? $this->ask('Enter a domain name (e.g node.example.com) to be used for connecting to the daemon. An IP address may only be used if you are not using SSL for this node');
+        $data['internal_fqdn'] = $this->option('internal-fqdn') ?? $this->ask('Enter internal FQDN for panel-to-Wings communication (leave blank to use public FQDN)', '');
         $data['public'] = $this->option('public') ?? $this->confirm('Should this node be public? As a note, setting a node to private you will be denying the ability to auto-deploy to this node.', true);
         $data['behind_proxy'] = $this->option('proxy') ?? $this->confirm('Is your FQDN behind a proxy?');
         $data['maintenance_mode'] = $this->option('maintenance') ?? $this->confirm('Should maintenance mode be enabled?');

--- a/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
+++ b/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
@@ -61,7 +61,7 @@ class WebsocketController extends ClientApiController
             ])
             ->handle($node, $user->id . $server->uuid);
 
-        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $node->getConnectionAddress());
+        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $node->getBrowserConnectionAddress());
 
         return new JsonResponse([
             'data' => [

--- a/app/Http/Requests/Admin/Node/NodeFormRequest.php
+++ b/app/Http/Requests/Admin/Node/NodeFormRequest.php
@@ -14,11 +14,14 @@ class NodeFormRequest extends AdminFormRequest
     public function rules(): array
     {
         if ($this->method() === 'PATCH') {
-            return Node::getRulesForUpdate($this->route()->parameter('node'));
+            $rules = Node::getRulesForUpdate($this->route()->parameter('node'));
+            $rules['internal_fqdn'] = ['nullable', 'string', Fqdn::make('scheme')];
+            return $rules;
         }
 
         $data = Node::getRules();
         $data['fqdn'][] = Fqdn::make('scheme');
+        $data['internal_fqdn'] = ['nullable', 'string', Fqdn::make('scheme')];
 
         return $data;
     }

--- a/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
+++ b/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
@@ -22,6 +22,7 @@ class StoreNodeRequest extends ApplicationApiRequest
             'name',
             'location_id',
             'fqdn',
+            'internal_fqdn',
             'scheme',
             'behind_proxy',
             'maintenance_mode',

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -20,6 +20,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
  * @property string|null $description
  * @property int $location_id
  * @property string $fqdn
+ * @property string|null $internal_fqdn
+ * @property bool $use_separate_fqdns
  * @property string $scheme
  * @property bool $behind_proxy
  * @property bool $maintenance_mode
@@ -77,18 +79,31 @@ class Node extends Model
         'behind_proxy' => 'boolean',
         'public' => 'boolean',
         'maintenance_mode' => 'boolean',
+        'use_separate_fqdns' => 'boolean',
     ];
 
     /**
      * Fields that are mass assignable.
      */
     protected $fillable = [
-        'public', 'name', 'location_id',
-        'fqdn', 'scheme', 'behind_proxy',
-        'memory', 'memory_overallocate', 'disk',
-        'disk_overallocate', 'upload_size', 'daemonBase',
-        'daemonSFTP', 'daemonListen',
-        'description', 'maintenance_mode',
+        'public',
+        'name',
+        'location_id',
+        'fqdn',
+        'internal_fqdn',
+        'use_separate_fqdns',
+        'scheme',
+        'behind_proxy',
+        'memory',
+        'memory_overallocate',
+        'disk',
+        'disk_overallocate',
+        'upload_size',
+        'daemonBase',
+        'daemonSFTP',
+        'daemonListen',
+        'description',
+        'maintenance_mode',
     ];
 
     public static array $validationRules = [
@@ -97,6 +112,8 @@ class Node extends Model
         'location_id' => 'required|exists:locations,id',
         'public' => 'boolean',
         'fqdn' => 'required|string',
+        'internal_fqdn' => 'nullable|string',
+        'use_separate_fqdns' => 'sometimes|boolean',
         'scheme' => 'required',
         'behind_proxy' => 'boolean',
         'memory' => 'required|numeric|min:1',
@@ -122,14 +139,40 @@ class Node extends Model
         'daemonSFTP' => 2022,
         'daemonListen' => 8080,
         'maintenance_mode' => false,
+        'use_separate_fqdns' => false,
     ];
 
     /**
      * Get the connection address to use when making calls to this node.
+     * This will use the internal FQDN if separate FQDNs are enabled and internal_fqdn is set,
+     * otherwise it will fall back to the regular fqdn.
      */
     public function getConnectionAddress(): string
     {
+        $fqdn = $this->getInternalFqdn();
+        return sprintf('%s://%s:%s', $this->scheme, $fqdn, $this->daemonListen);
+    }
+
+    /**
+     * Get the browser connection address for WebSocket connections.
+     * This always uses the public fqdn field.
+     */
+    public function getBrowserConnectionAddress(): string
+    {
         return sprintf('%s://%s:%s', $this->scheme, $this->fqdn, $this->daemonListen);
+    }
+
+    /**
+     * Get the appropriate FQDN for internal panel-to-Wings communication.
+     */
+    public function getInternalFqdn(): string
+    {
+        // Use internal FQDN if it's provided and not empty
+        if (!empty($this->internal_fqdn)) {
+            return $this->internal_fqdn;
+        }
+
+        return $this->fqdn;
     }
 
     /**
@@ -147,8 +190,8 @@ class Node extends Model
                 'port' => $this->daemonListen,
                 'ssl' => [
                     'enabled' => (!$this->behind_proxy && $this->scheme === 'https'),
-                    'cert' => '/etc/letsencrypt/live/' . Str::lower($this->fqdn) . '/fullchain.pem',
-                    'key' => '/etc/letsencrypt/live/' . Str::lower($this->fqdn) . '/privkey.pem',
+                    'cert' => '/etc/letsencrypt/live/' . Str::lower($this->getInternalFqdn()) . '/fullchain.pem',
+                    'key' => '/etc/letsencrypt/live/' . Str::lower($this->getInternalFqdn()) . '/privkey.pem',
                 ],
                 'upload_limit' => $this->upload_size,
             ],

--- a/app/Services/Nodes/NodeCreationService.php
+++ b/app/Services/Nodes/NodeCreationService.php
@@ -28,6 +28,11 @@ class NodeCreationService
         $data['daemon_token'] = app(Encrypter::class)->encrypt(Str::random(Node::DAEMON_TOKEN_LENGTH));
         $data['daemon_token_id'] = Str::random(Node::DAEMON_TOKEN_ID_LENGTH);
 
+        // Automatically set use_separate_fqdns based on whether internal_fqdn is provided
+        if (isset($data['internal_fqdn'])) {
+            $data['use_separate_fqdns'] = !empty($data['internal_fqdn']);
+        }
+
         return $this->repository->create($data, true, true);
     }
 }

--- a/database/migrations/2025_05_25_230411_add_internal_fqdn_to_nodes_table.php
+++ b/database/migrations/2025_05_25_230411_add_internal_fqdn_to_nodes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  /**
+   * Run the migrations.
+   */
+  public function up(): void
+  {
+    Schema::table('nodes', function (Blueprint $table) {
+      $table->string('internal_fqdn')->nullable()->after('fqdn');
+      $table->boolean('use_separate_fqdns')->default(false)->after('internal_fqdn');
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   */
+  public function down(): void
+  {
+    Schema::table('nodes', function (Blueprint $table) {
+      $table->dropColumn(['internal_fqdn', 'use_separate_fqdns']);
+    });
+  }
+};

--- a/docker-compose.develop.yml
+++ b/docker-compose.develop.yml
@@ -1,15 +1,4 @@
 x-common:
-    wings: &wings-environment
-        # The panel needs the to use the same FQDN/IP accessible in both the container & host, so a static IP is required.
-        # If you change it, you will need to update it in "http://localhost:3000/admin/nodes/view/1/settings" too, or down
-        # the compose, delete the "srv" folder, then up it again.
-        #
-        # Rootless Docker can't expose the IPs, so accessing Wings from the host won't work.
-        # https://docs.docker.com/engine/security/rootless/#known-limitations
-        #
-        # macOS Docker Desktop users will need to install https://github.com/chipmk/docker-mac-net-connect for Wings to work.
-        # macOS OrbStack & Linux users shouldn't need to install the above.
-        ipv4: &wings-ipv4 172.20.0.99
     database: &db-environment
         # Do not remove the "&db-password" from the end of the line below, it is important
         # for Panel functionality.
@@ -93,7 +82,7 @@ services:
             DB_HOST: 'database'
             DB_PORT: '3306'
             HASHIDS_LENGTH: 8
-            WINGS_IP: *wings-ipv4
+            WINGS_INTERNAL_IP: 'wings'
             WINGS_DIR: '${PWD}'
             PYRODACTYL_DOCKER_DEV: 'true'
     wings:
@@ -103,9 +92,6 @@ services:
         # image: ghcr.io/pterodactyl/wings:latest
         image: ghcr.io/he3als/wings-mac:latest
         restart: always
-        networks:
-            default:
-                ipv4_address: *wings-ipv4
         ports:
             - '8080:8080'
             - '2022:2022'

--- a/resources/views/admin/nodes/new.blade.php
+++ b/resources/views/admin/nodes/new.blade.php
@@ -55,9 +55,28 @@
                         <p class="text-muted small">By setting a node to <code>private</code> you will be denying the ability to auto-deploy to this node.
                     </div>
                     <div class="form-group">
-                        <label for="pFQDN" class="form-label">FQDN</label>
-                        <input type="text" name="fqdn" id="pFQDN" class="form-control" value="{{ old('fqdn') }}"/>
-                        <p class="text-muted small">Please enter domain name (e.g <code>node.example.com</code>) to be used for connecting to the daemon. An IP address may be used <em>only</em> if you are not using SSL for this node.</p>
+                        <label for="pFQDN" class="form-label">Public FQDN</label>
+                        <input type="text" name="fqdn" id="pFQDN" class="form-control" value="{{ old('fqdn') }}" />
+                        <p class="text-muted small">
+                            Domain name that browsers will use to connect to Wings (e.g <code>wings.example.com</code>).
+                            An IP address may be used <em>only</em> if you are not using SSL for this node.
+                        </p>
+                    </div>
+                    <div class="form-group">
+                        <label for="pInternalFQDN" class="form-label">
+                            Internal FQDN
+                            <strong>(Optional)</strong>
+                        </label>
+                        <input type="text" name="internal_fqdn" id="pInternalFQDN" class="form-control"
+                            value="{{ old('internal_fqdn') }}" />
+                        <p class="text-muted small">
+                            <strong>Optional:</strong>
+                            Leave blank to use the Public FQDN for panel-to-Wings communication.
+                            If specified, this internal domain name will be used for panel-to-Wings communication instead
+                            (e.g <code>wings-internal.example.com</code> or <code>10.0.0.5</code>).
+                            Useful for internal networks where the panel needs to communicate with Wings using a
+                            different address than what browsers use.
+                        </p>
                     </div>
                     <div class="form-group">
                         <label class="form-label">Communicate Over SSL</label>

--- a/resources/views/admin/nodes/view/settings.blade.php
+++ b/resources/views/admin/nodes/view/settings.blade.php
@@ -67,13 +67,39 @@
                         </div>
                     </div>
                     <div class="form-group col-xs-12">
-                        <label for="fqdn" class="control-label">Fully Qualified Domain Name</label>
+                        <label for="fqdn" class="control-label">Public Fully Qualified Domain Name</label>
                         <div>
-                            <input type="text" autocomplete="off" name="fqdn" class="form-control" value="{{ old('fqdn', $node->fqdn) }}" />
+                            <input type="text" autocomplete="off" name="fqdn" class="form-control"
+                                value="{{ old('fqdn', $node->fqdn) }}" />
                         </div>
-                        <p class="text-muted"><small>Please enter domain name (e.g <code>node.example.com</code>) to be used for connecting to the daemon. An IP address may only be used if you are not using SSL for this node.
-                                <a tabindex="0" data-toggle="popover" data-trigger="focus" title="Why do I need a FQDN?" data-content="In order to secure communications between your server and this node we use SSL. We cannot generate a SSL certificate for IP Addresses, and as such you will need to provide a FQDN.">Why?</a>
-                            </small></p>
+                        <p class="text-muted">
+                            <small>
+                                Domain name that browsers will use to connect to Wings (e.g <code>wings.example.com</code>).
+                                An IP address may be used <em>only</em> if you are not using SSL for this node.
+                                <a tabindex="0" data-toggle="popover" data-trigger="focus" title="Why do I need a FQDN?"
+                                    data-content="In order to secure communications between your server and this node we use SSL. We cannot generate a SSL certificate for IP Addresses, and as such you will need to provide a FQDN.">Why?</a>
+                            </small>
+                        </p>
+                    </div>
+                    <div class="form-group col-xs-12">
+                        <label for="internal_fqdn" class="control-label">
+                            Internal FQDN
+                            <strong>(Optional)</strong>
+                        </label>
+                        <div>
+                            <input type="text" autocomplete="off" name="internal_fqdn" class="form-control"
+                                value="{{ old('internal_fqdn', $node->internal_fqdn) }}" />
+                        </div>
+                        <p class="text-muted">
+                            <small>
+                                <strong>Optional:</strong>
+                                Leave blank to use the Public FQDN for panel-to-Wings communication.
+                                If specified, this internal domain name will be used for panel-to-Wings communication instead
+                                (e.g <code>wings-internal.example.com</code> or <code>10.0.0.5</code>).
+                                Useful for internal networks where the panel needs to communicate with Wings using a
+                                different address than what browsers use.
+                            </small>
+                        </p>
                     </div>
                     <div class="form-group col-xs-12">
                         <label class="form-label"><span class="label label-warning"><i class="fa fa-power-off"></i></span> Communicate Over SSL</label>


### PR DESCRIPTION
Separates the Wings FQDN option into public and internal:

- Public is the publicly accessible FQDN that browsers connect to
- Internal is what the panel uses to connect to Wings internally (optional)
	- If not specified, public is used

Before this PR, Docker dev required container internal IPs to be accessible from the host. This meant rootless Docker didn't work, that https://github.com/chipmk/docker-mac-net-connect was required on macOS Docker Desktop, and that Wings connection would never work on Windows.

However, this PR fixes those issues, while maintaining network isolation. Docs PR: https://github.com/pyrohost/pyrodactyl-docs/pull/16