### PR TITLE
fix: login doesn't work on first launch

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -8,7 +8,9 @@ mkdir -p /var/log/panel/logs/ /var/log/supervisord/ /var/log/nginx/ /var/log/php
 # Ensure proper permissions for Laravel storage directories
 mkdir -p /app/storage/logs /app/storage/framework/cache /app/storage/framework/sessions /app/storage/framework/views \
   && chmod -R 777 /app/storage/ \
-  && chmod g+s /app/storage/logs/
+
+chmod g+s /app/storage/logs/
+chown nginx:nginx /app/storage/logs/
 
 # Check that user has mounted the /app/var directory
 if [ ! -d /app/var ]; then

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -7,7 +7,8 @@ mkdir -p /var/log/panel/logs/ /var/log/supervisord/ /var/log/nginx/ /var/log/php
 
 # Ensure proper permissions for Laravel storage directories
 mkdir -p /app/storage/logs /app/storage/framework/cache /app/storage/framework/sessions /app/storage/framework/views \
-  && chmod -R 777 /app/storage/
+  && chmod -R 777 /app/storage/ \
+  && chmod g+s /app/storage/logs/
 
 # Check that user has mounted the /app/var directory
 if [ ! -d /app/var ]; then

--- a/config/logging.php
+++ b/config/logging.php
@@ -69,6 +69,7 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 7),
             'replace_placeholders' => true,
+            'permission' => 0664,
         ],
 
         'slack' => [


### PR DESCRIPTION
pre-pr:
logs are created with 0644, by root during the first laucnh setup stuff
that initial log is owned by root
relaunching the container chmod -R 777s the parent /app/storage directory, which means logs can be written to

if logs fail, the error goes all the way up to the login and users can't log in

post-pr:
logs are created with 0664, by root during the first launche setup stuff, but have the group as nginx because the setgid bit is set on /app/storage/logs, which is also owned by nginx now
log still owned by root, but nginx group members can still rw
relaunching the container still chmods, but the permissions are already set correctly on logs